### PR TITLE
BCSD Code Updates for LIS 7.5.11 PR

### DIFF
--- a/lis/utils/usaf/s2s/s2s_app/s2s_run.sh
+++ b/lis/utils/usaf/s2s/s2s_app/s2s_run.sh
@@ -580,7 +580,7 @@ bcsd_fcst(){
     # Task 4: Monthly "BC" step applied to CFSv2 (forecast_task_04.py, after 1 and 3)
     # -------------------------------------------------------------------------------
     jobname=bcsd04
-    python $LISHDIR/s2s_modules/bcsd_fcst/forecast_task_04.py -s $YYYY -e $YYYY -m $mmm -n $MM -c $BWD/$CFILE -w ${CWD} -t 1 -H 4 -j $jobname
+    python $LISHDIR/s2s_modules/bcsd_fcst/forecast_task_04.py -s $YYYY -e $YYYY -m $mmm -n $MM -c $BWD/$CFILE -w ${CWD} -t 1 -H 3 -j $jobname
     
     unset job_list
     job_list="$jobname*.j"
@@ -601,7 +601,7 @@ bcsd_fcst(){
     jobname=bcsd05
     for model in $MODELS
     do
-	python $LISHDIR/s2s_modules/bcsd_fcst/forecast_task_05.py -s $YYYY -e $YYYY -m $mmm -n $MM -c $BWD/$CFILE -w ${CWD} -t 1 -H 4 -M $model -j $jobname    
+	python $LISHDIR/s2s_modules/bcsd_fcst/forecast_task_05.py -s $YYYY -e $YYYY -m $mmm -n $MM -c $BWD/$CFILE -w ${CWD} -t 1 -H 3 -M $model -j $jobname    
     done
     
     unset job_list
@@ -621,7 +621,7 @@ bcsd_fcst(){
     # Task 6: CFSv2 Temporal Disaggregation (forecast_task_06.py: after 4 and 5)
     # --------------------------------------------------------------------------
     jobname=bcsd06
-    python $LISHDIR/s2s_modules/bcsd_fcst/forecast_task_06.py -s $YYYY -e $YYYY -m $mmm -n $MM -c $BWD/$CFILE -w ${CWD} -p ${E2ESDIR} -t 1 -H 4 -j $jobname
+    python $LISHDIR/s2s_modules/bcsd_fcst/forecast_task_06.py -s $YYYY -e $YYYY -m $mmm -n $MM -c $BWD/$CFILE -w ${CWD} -p ${E2ESDIR} -t 1 -H 2 -j $jobname
     
     unset job_list
     job_list=`ls $jobname*.j`
@@ -646,7 +646,7 @@ bcsd_fcst(){
     jobname=bcsd08
     for model in $MODELS
     do
-	python $LISHDIR/s2s_modules/bcsd_fcst/forecast_task_08.py -s $YYYY -e $YYYY -m $mmm -n $MM -c $BWD/$CFILE -w ${CWD} -p ${E2ESDIR} -t 1 -H 6 -M $model -j $jobname    
+	python $LISHDIR/s2s_modules/bcsd_fcst/forecast_task_08.py -s $YYYY -e $YYYY -m $mmm -n $MM -c $BWD/$CFILE -w ${CWD} -p ${E2ESDIR} -t 1 -H 3 -M $model -j $jobname    
     done
     
     unset job_list

--- a/lis/utils/usaf/s2s/s2s_modules/bcsd_fcst/bcsd_library/bcsd_function.py
+++ b/lis/utils/usaf/s2s/s2s_modules/bcsd_fcst/bcsd_library/bcsd_function.py
@@ -1,6 +1,7 @@
 """
 #
 """
+
 #-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
 # NASA Goddard Space Flight Center
 # Land Information System Framework (LISF)
@@ -10,6 +11,7 @@
 # Administrator of the National Aeronautics and Space Administration.
 # All Rights Reserved.
 # -------------------------END NOTICE -- DO NOT EDIT-----------------------
+
 
 import numpy as np
 #import calendar

--- a/lis/utils/usaf/s2s/s2s_modules/bcsd_fcst/bcsd_library/bcsd_function.py
+++ b/lis/utils/usaf/s2s/s2s_modules/bcsd_fcst/bcsd_library/bcsd_function.py
@@ -10,7 +10,7 @@
 # Copyright (c) 2022 United States Government as represented by the
 # Administrator of the National Aeronautics and Space Administration.
 # All Rights Reserved.
-# -------------------------END NOTICE -- DO NOT EDIT-----------------------
+#-------------------------END NOTICE -- DO NOT EDIT-----------------------
 
 
 import numpy as np

--- a/lis/utils/usaf/s2s/s2s_modules/bcsd_fcst/bcsd_library/bcsd_function.py
+++ b/lis/utils/usaf/s2s/s2s_modules/bcsd_fcst/bcsd_library/bcsd_function.py
@@ -1,19 +1,15 @@
 """
 #
 """
-'''
-
------------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
-NASA Goddard Space Flight Center
-Land Information System Framework (LISF)
-Version 7.4
-
-Copyright (c) 2022 United States Government as represented by the
-Administrator of the National Aeronautics and Space Administration.
-All Rights Reserved.
--------------------------END NOTICE -- DO NOT EDIT-----------------------
-    
-'''
+#-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+# NASA Goddard Space Flight Center
+# Land Information System Framework (LISF)
+# Version 7.4
+#
+# Copyright (c) 2022 United States Government as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# All Rights Reserved.
+# -------------------------END NOTICE -- DO NOT EDIT-----------------------
 
 import numpy as np
 #import calendar
@@ -32,7 +28,7 @@ class VarLimits:
     def clip_array (self, data_array, var_name=None, min_val=None, max_val=None,
                     missing=None, min_thres=None, precip=None):
         ''' Below limits are 6h based'''
-        min_limit={'PRECTOT': 1.e-6,
+        min_limit={'PRECTOT': 1.e-7,
                   'PS': 30000.,
                   'T2M': 180.,
                   'LWS': 10.,

--- a/lis/utils/usaf/s2s/s2s_modules/bcsd_fcst/bcsd_library/bcsd_stats_functions.py
+++ b/lis/utils/usaf/s2s/s2s_modules/bcsd_fcst/bcsd_library/bcsd_stats_functions.py
@@ -4,19 +4,17 @@
 # coding: utf-8
 #Author: Shrad Shukla
 """
-'''
 
------------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
-NASA Goddard Space Flight Center
-Land Information System Framework (LISF)
-Version 7.4
+#-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+# NASA Goddard Space Flight Center
+# Land Information System Framework (LISF)
+# Version 7.4
+#
+# Copyright (c) 2022 United States Government as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# All Rights Reserved.
+#-------------------------END NOTICE -- DO NOT EDIT-----------------------
 
-Copyright (c) 2022 United States Government as represented by the
-Administrator of the National Aeronautics and Space Administration.
-All Rights Reserved.
--------------------------END NOTICE -- DO NOT EDIT-----------------------
-    
-'''
 
 from datetime import datetime
 import sys
@@ -61,8 +59,11 @@ def write_4d_netcdf(infile, var, varname, description, source, var_units, sig_di
     latitudes = rootgrp.createVariable('latitude','f4',('latitude',))
     times = rootgrp.createVariable('time','f8',('time',))
     # two dimensions unlimited.
+#    varname = rootgrp.createVariable(varname,'f4',('time', 'Lead', 'Ens', 'latitude','longitude'), \
+#                                     fill_value=nc4_default_fillvals['f4'], zlib=True, \
+#                                     complevel=6, shuffle=True)
     varname = rootgrp.createVariable(varname,'f4',('time', 'Lead', 'Ens', 'latitude','longitude'), \
-                                     fill_value=nc4_default_fillvals['f4'], zlib=True, \
+                                     fill_value=-9999., zlib=True, \
                                      complevel=6, shuffle=True)
     rootgrp.description = description
     rootgrp.history = 'Created ' + t_ctime(t_time())

--- a/lis/utils/usaf/s2s/s2s_modules/bcsd_fcst/bcsd_library/bias_correction_modulefast.py
+++ b/lis/utils/usaf/s2s/s2s_modules/bcsd_fcst/bcsd_library/bias_correction_modulefast.py
@@ -7,21 +7,18 @@
 #This module bias corrects a forecasts following
 #probability mapping approach as described in Wood et al. 2002
 #Date: August 06, 2015
-# In[28]:
 """
-'''
 
------------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
-NASA Goddard Space Flight Center
-Land Information System Framework (LISF)
-Version 7.4
+#-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+# NASA Goddard Space Flight Center
+# Land Information System Framework (LISF)
+# Version 7.4
+#
+# Copyright (c) 2022 United States Government as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# All Rights Reserved.
+#-------------------------END NOTICE -- DO NOT EDIT-----------------------
 
-Copyright (c) 2022 United States Government as represented by the
-Administrator of the National Aeronautics and Space Administration.
-All Rights Reserved.
--------------------------END NOTICE -- DO NOT EDIT-----------------------
-    
-'''
 
 import calendar
 import sys
@@ -34,7 +31,19 @@ import numpy as np
 from shrad_modules import read_nc_files
 from bcsd_stats_functions import write_4d_netcdf, get_domain_info
 from bcsd_function import calc_bcsd
+from bcsd_function import VarLimits as lim
 # pylint: enable=import-error
+
+limits = lim()
+CF2VAR = {
+    'PRECTOT': 'PRECTOT',
+    'LWS': 'LWS',
+    'SLRSF': 'SLRSF',
+    'PS': 'PS',
+    'Q2M':'Q2M',
+    'T2M': 'T2M',
+    'WIND10M': 'WIND',
+    }
 
 ## Usage: <Name of variable in observed climatology>
 ## <Name of variable in reforecast climatology
@@ -205,6 +214,11 @@ def monthly_calculations(mon):
 
     correct_fcst_coarse = np.ma.masked_array(correct_fcst_coarse, \
                                              mask=correct_fcst_coarse == -9999.)
+
+    # clip limits - monthly BC NMME precip:
+    correct_fcst_coarse = limits.clip_array(correct_fcst_coarse, \
+            var_name=CF2VAR.get(FCST_VAR))
+
     outfile = OUTFILE_TEMPLATE.format(OUTDIR, FCST_VAR, month_name, \
               TARGET_FCST_SYR, TARGET_FCST_EYR)
     print(f"Now writing {outfile}")

--- a/lis/utils/usaf/s2s/s2s_modules/bcsd_fcst/bcsd_library/bias_correction_nmme_modulefast.py
+++ b/lis/utils/usaf/s2s/s2s_modules/bcsd_fcst/bcsd_library/bias_correction_nmme_modulefast.py
@@ -7,21 +7,18 @@
 #This module bias corrects a forecasts following
 #probability mapping approach as described in Wood et al. 2002
 #Date: August 06, 2015
-# In[28]:
 """
-'''
 
------------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
-NASA Goddard Space Flight Center
-Land Information System Framework (LISF)
-Version 7.4
+#-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+# NASA Goddard Space Flight Center
+# Land Information System Framework (LISF)
+# Version 7.4
+#
+# Copyright (c) 2022 United States Government as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# All Rights Reserved.
+#-------------------------END NOTICE -- DO NOT EDIT-----------------------
 
-Copyright (c) 2022 United States Government as represented by the
-Administrator of the National Aeronautics and Space Administration.
-All Rights Reserved.
--------------------------END NOTICE -- DO NOT EDIT-----------------------
-    
-'''
 
 import os
 import sys
@@ -31,10 +28,14 @@ import numpy as np
 from dateutil.relativedelta import relativedelta
 import xarray as xr
 # pylint: disable=import-error
+import yaml
 import bcsd_function
 from bcsd_stats_functions import write_4d_netcdf, get_domain_info
+from bcsd_function import VarLimits as lim
 from shrad_modules import read_nc_files
 # pylint: enable=import-error
+
+limits = lim()
 
 def get_index(ref_array, my_value):
     """
@@ -67,7 +68,7 @@ def slice_latlon(lat, lon, lat_range: list, lon_range: list):
     return indexlat, indexlon
 
 # Small number
-EPS = 1.0e-5
+#EPS = 1.0e-5
 
 ## Usage: <Name of variable in observed climatology>
 ## <Name of variable in reforecast climatology
@@ -108,9 +109,9 @@ MONTH_NAME_TEMPLATE = '{}01'
 # GEOS5 filename TEMPLATE:
 FCST_INFILE_TEMPLATE = '{}/{}/{:04d}/ens{:01d}/{}.nmme.monthly.{:04d}{:02d}.nc'
 
-CONFIG_FILE = str(sys.argv[16])
-LAT1, LAT2, LON1, LON2 = get_domain_info(CONFIG_FILE, extent=True)
-LATS, LONS = get_domain_info(CONFIG_FILE, coord=True)
+CONFIGFILE = str(sys.argv[16])
+LAT1, LAT2, LON1, LON2 = get_domain_info(CONFIGFILE, extent=True)
+LATS, LONS = get_domain_info(CONFIGFILE, coord=True)
 
 ### Output directory
 OUTFILE_TEMPLATE = '{}/{}.{}.{}_{:04d}_{:04d}.nc'
@@ -130,6 +131,13 @@ TINY = ((1/(NUM_YRS))/ENS_NUM)/2
 ## forecasted value happened to be an outlier of the
 ## reforecast climatology
 
+# Read in LDT landmask - impose on precip field prior to BC:
+with open(CONFIGFILE, 'r', encoding="utf-8") as file:
+    config = yaml.safe_load(file)
+ldt_xr = xr.open_dataset(config['SETUP']['supplementarydir'] + '/lis_darun/' + \
+        config['SETUP']['ldtinputfile'])
+mask_2d = np.array(ldt_xr['LANDMASK'].values)
+mask_exp = mask_2d[np.newaxis, np.newaxis, np.newaxis,:,:]
 
 ##### Starting bias-correction from here
 
@@ -198,8 +206,16 @@ for MON in [INIT_FCST_MON]:
     np_FCST_CLIM_ARRAY, LEAD_FINAL, TARGET_FCST_EYR, TARGET_FCST_SYR, \
     FCST_SYR, ENS_NUM, MON, BC_VAR, TINY, FCST_COARSE)
 
+    mask = np.broadcast_to(mask_exp, CORRECT_FCST_COARSE.shape)
+    CORRECT_FCST_COARSE[mask == 0] = -9999.
+
     CORRECT_FCST_COARSE = np.ma.masked_array(CORRECT_FCST_COARSE, \
                                              mask=CORRECT_FCST_COARSE == -9999.)
+
+   # clip limits - monthly BC NMME precip:
+    CORRECT_FCST_COARSE = limits.clip_array(CORRECT_FCST_COARSE, var_name="PRECTOT", \
+                                             max_val=0.004, precip=True)
+
     OUTFILE = OUTFILE_TEMPLATE.format(OUTDIR, FCST_VAR, MODEL_NAME, \
     MONTH_NAME, TARGET_FCST_SYR, TARGET_FCST_EYR)
     print(f"Now writing {OUTFILE}")

--- a/lis/utils/usaf/s2s/s2s_modules/bcsd_fcst/bcsd_library/calc_and_write_observational_climatology.py
+++ b/lis/utils/usaf/s2s/s2s_modules/bcsd_fcst/bcsd_library/calc_and_write_observational_climatology.py
@@ -7,19 +7,17 @@
 # Wood et al. 2002
 # Date: August 06, 2015
 """
-'''
 
------------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
-NASA Goddard Space Flight Center
-Land Information System Framework (LISF)
-Version 7.4
+#-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+# NASA Goddard Space Flight Center
+# Land Information System Framework (LISF)
+# Version 7.4
+#
+# Copyright (c) 2022 United States Government as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# All Rights Reserved.
+#-------------------------END NOTICE -- DO NOT EDIT-----------------------
 
-Copyright (c) 2022 United States Government as represented by the
-Administrator of the National Aeronautics and Space Administration.
-All Rights Reserved.
--------------------------END NOTICE -- DO NOT EDIT-----------------------
-    
-'''
 
 import os
 import sys
@@ -75,13 +73,18 @@ if not os.path.exists(OUTDIR):
 INFILE_TEMPLATE = '{}/{:04d}{:02d}/LIS_HIST_{:04d}{:02d}010000.d01.nc'
 OUTFILE_TEMPLATE = '{}/{}_obs_clim.nc'
 
+# Read in LDT landmask - impose on precip field prior to BC:
+ldt_xr = xr.open_dataset(config['SETUP']['supplementarydir'] + '/lis_darun/' + \
+        config['SETUP']['ldtinputfile'])
+mask = np.array(ldt_xr['LANDMASK'].values)
+
 ## Defining array to store observed data
 OBS_DATA_COARSE = np.empty((((CLIM_EYR-CLIM_SYR)+1)*12, len(LATS), len(LONS)))
 
 MON_COUNTER = 0
 for YEAR in range(CLIM_SYR, CLIM_EYR+1):
     for MON in range(0, 12):
-		    #INFILE = INFILE_TEMPLATE.format(INDIR, YEAR, MON+1, YEAR, MON+1)
+        # INFILE = INFILE_TEMPLATE.format(INDIR, YEAR, MON+1, YEAR, MON+1)
         # LIS_HIST monthly file directory is month + 1
         lis_year = YEAR
         lis_month = MON+2
@@ -91,6 +94,9 @@ for YEAR in range(CLIM_SYR, CLIM_EYR+1):
         INFILE = INFILE_TEMPLATE.format(INDIR, lis_year, lis_month, lis_year, lis_month)
         print (f"Reading Observed Data {INFILE}")
         OBS_DATA_COARSE[MON_COUNTER, ] = read_nc_files(INFILE, VAR_NAME)
+#       Impose mask on precip values:
+        if VAR_NAME == 'Rainf_f_tavg':
+           OBS_DATA_COARSE[MON_COUNTER,mask == 0] = -9999.
         MON_COUNTER+=1
 
 ## Looping through each month and creating time series of quantiles and observed climatology

--- a/lis/utils/usaf/s2s/s2s_modules/bcsd_fcst/bcsd_library/nmme_reorg_f.py
+++ b/lis/utils/usaf/s2s/s2s_modules/bcsd_fcst/bcsd_library/nmme_reorg_f.py
@@ -7,21 +7,18 @@
 #  Removed basemap call and added xarray and xesmf
 #  module calls
 #  Date: Nov 07, 2022
-# In[28]:
 """
-'''
 
------------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
-NASA Goddard Space Flight Center
-Land Information System Framework (LISF)
-Version 7.4
+#-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+# NASA Goddard Space Flight Center
+# Land Information System Framework (LISF)
+# Version 7.4
+#
+# Copyright (c) 2022 United States Government as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# All Rights Reserved.
+#-------------------------END NOTICE -- DO NOT EDIT-----------------------
 
-Copyright (c) 2022 United States Government as represented by the
-Administrator of the National Aeronautics and Space Administration.
-All Rights Reserved.
--------------------------END NOTICE -- DO NOT EDIT-----------------------
-    
-'''
 
 from datetime import datetime
 import os
@@ -225,7 +222,7 @@ for m in range(0, ENS_NUM):
             os.makedirs(OUTDIR)
 
         XPRECI = np.nan_to_num(XPRECI, nan=-9999.)
-        XPRECI = limits.clip_array(XPRECI, var_name="PRECTOT", max_val=0.022, precip=True)
+        XPRECI = limits.clip_array(XPRECI, var_name="PRECTOT", max_val=0.004, precip=True)
         LATS = np.nan_to_num(LATS, nan=-9999.)
         LONS = np.nan_to_num(LONS, nan=-9999.)
 

--- a/lis/utils/usaf/s2s/s2s_modules/bcsd_fcst/bcsd_library/nmme_reorg_h.py
+++ b/lis/utils/usaf/s2s/s2s_modules/bcsd_fcst/bcsd_library/nmme_reorg_h.py
@@ -4,21 +4,18 @@
 #This module reorganizes
 #NMME preciptation forecasts
 #Date: May 06, 2021
-# In[28]:
 """
-'''
 
------------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
-NASA Goddard Space Flight Center
-Land Information System Framework (LISF)
-Version 7.4
+#-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+# NASA Goddard Space Flight Center
+# Land Information System Framework (LISF)
+# Version 7.4
+#
+# Copyright (c) 2022 United States Government as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# All Rights Reserved.
+#-------------------------END NOTICE -- DO NOT EDIT-----------------------
 
-Copyright (c) 2022 United States Government as represented by the
-Administrator of the National Aeronautics and Space Administration.
-All Rights Reserved.
--------------------------END NOTICE -- DO NOT EDIT-----------------------
-    
-'''
 
 from datetime import datetime
 import os
@@ -275,7 +272,7 @@ for y in range(0, 40):
                 os.makedirs(OUTDIR)
 
             XPRECI = np.nan_to_num(XPRECI, nan=-9999.)
-            XPRECI = limits.clip_array(XPRECI, var_name="PRECTOT", max_val=0.022, precip=True)
+            XPRECI = limits.clip_array(XPRECI, var_name="PRECTOT", max_val=0.004, precip=True)
             LATS = np.nan_to_num(LATS, nan=-9999.)
             LONS = np.nan_to_num(LONS, nan=-9999.)
 

--- a/lis/utils/usaf/s2s/s2s_modules/bcsd_fcst/bcsd_library/temporal_disaggregation_6hourly_module.py
+++ b/lis/utils/usaf/s2s/s2s_modules/bcsd_fcst/bcsd_library/temporal_disaggregation_6hourly_module.py
@@ -7,21 +7,18 @@
 #This module bias corrects a forecasts following probability
 #mapping approach as described in Wood et al. 2002
 #Date: August 06, 2015
-# In[28]:
 """
-'''
 
------------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
-NASA Goddard Space Flight Center
-Land Information System Framework (LISF)
-Version 7.4
+#-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+# NASA Goddard Space Flight Center
+# Land Information System Framework (LISF)
+# Version 7.4
+#
+# Copyright (c) 2022 United States Government as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# All Rights Reserved.
+#-------------------------END NOTICE -- DO NOT EDIT-----------------------
 
-Copyright (c) 2022 United States Government as represented by the
-Administrator of the National Aeronautics and Space Administration.
-All Rights Reserved.
--------------------------END NOTICE -- DO NOT EDIT-----------------------
-    
-'''
 
 import os
 import sys
@@ -42,7 +39,6 @@ from bcsd_function import VarLimits as lim
 # pylint: enable=import-error
 
 limits = lim()
-PRECIP_THRES = limits.precip_thres
 
 CF2VAR = {
     'PRECTOT': 'PRECTOT',
@@ -56,14 +52,11 @@ CF2VAR = {
 
 def scale_forcings (mon_bc_value, mon_raw_value, input_raw_data, bc_var = None):
     ''' perform scaling '''
-    global PRECIP_THRES
     output_bc_data = np.ones(len(input_raw_data))*-9999.
 
     if bc_var == 'PRCP':
-        if mon_raw_value < PRECIP_THRES:
-            correction_factor = mon_bc_value
-            ## HACK## for when input monthly value is 0
-            output_bc_data[:] = correction_factor
+        if mon_raw_value == 0.:
+            output_bc_data[:] = mon_bc_value
         else:
             correction_factor = mon_bc_value/mon_raw_value
             output_bc_data[:] = input_raw_data[:]*correction_factor
@@ -269,6 +262,7 @@ for MON in [INIT_FCST_MON]:
                 OUTPUT_BC_DATA = limits.clip_array(OUTPUT_BC_DATA, var_name=CF2VAR.get(OBS_VAR), precip=True)
             else:
                 OUTPUT_BC_DATA = limits.clip_array(OUTPUT_BC_DATA, var_name=CF2VAR.get(OBS_VAR))
+
             print(f"Now writing {OUTFILE}")
             OUTPUT_BC_DATA = np.ma.masked_array(OUTPUT_BC_DATA, \
                                                 mask=OUTPUT_BC_DATA == -9999.)

--- a/lis/utils/usaf/s2s/s2s_modules/bcsd_fcst/bcsd_library/temporal_disaggregation_nmme_6hourly_module.py
+++ b/lis/utils/usaf/s2s/s2s_modules/bcsd_fcst/bcsd_library/temporal_disaggregation_nmme_6hourly_module.py
@@ -7,21 +7,18 @@
 #This module bias corrects a forecasts following probability
 #mapping approach as described in Wood et al. 2002
 #Date: August 06, 2015
-# In[28]:
 """
-'''
 
------------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
-NASA Goddard Space Flight Center
-Land Information System Framework (LISF)
-Version 7.4
+#-----------------------BEGIN NOTICE -- DO NOT EDIT-----------------------
+# NASA Goddard Space Flight Center
+# Land Information System Framework (LISF)
+# Version 7.4
+#
+# Copyright (c) 2022 United States Government as represented by the
+# Administrator of the National Aeronautics and Space Administration.
+# All Rights Reserved.
+#-------------------------END NOTICE -- DO NOT EDIT-----------------------
 
-Copyright (c) 2022 United States Government as represented by the
-Administrator of the National Aeronautics and Space Administration.
-All Rights Reserved.
--------------------------END NOTICE -- DO NOT EDIT-----------------------
-    
-'''
 
 import os
 import sys
@@ -38,8 +35,8 @@ from netCDF4 import Dataset as nc4_dataset
 from netCDF4 import date2num as nc4_date2num
 # pylint: enable=no-name-in-module
 # pylint: disable=import-error
-from bcsd_stats_functions import get_domain_info
 from bcsd_function import VarLimits as lim
+from bcsd_stats_functions import get_domain_info
 # pylint: enable=import-error
 
 limits = lim()
@@ -72,7 +69,7 @@ def use_neighbors_diurnal_cycle (precip_data):
     useful_precip = ma.masked_array(total_precip, ~useful_cells_mask)
     tgt_cells_beg = np.sum(target_cells_mask)
 
-    for zoom in range (1,2):
+    for zoom in range (1,3):
         # starting from the 3x3 window from the location gradually increase upto 39x39 window
         for direction in (-1,1):
             shift = direction * zoom
@@ -135,26 +132,28 @@ def use_neighbors_diurnal_cycle (precip_data):
                 arrayb[t,idx]=arrayb_shifted[t,idx]*shifted_ratio[idx]
             target_cells_mask = target_cells_mask & ~idx
             current_precip = ma.masked_array(total_precip, target_cells_mask)
-            
+
+    for t in range (0,arrayb.shape[0]):
+        arrayb[t,target_cells_mask]= 0.
+
     tgt_cells_end = np.sum(target_cells_mask)
     return arrayb, tgt_cells_beg, tgt_cells_end
 
 def scale_forcings (mon_bc_value, mon_raw_value, input_raw_data, bc_var = None):
     ''' perform scaling '''
-    global PRECIP_THRES
     output_bc_data = np.ones(len(input_raw_data))*-9999.
 
     if bc_var == 'PRCP':
-        if mon_raw_value < PRECIP_THRES:
-            correction_factor = mon_bc_value
-            ## HACK## for when input monthly value is 0
-            output_bc_data[:] = correction_factor
+        if mon_bc_value == -9999:
+            return output_bc_data
+        if mon_raw_value == 0.:
+            output_bc_data[:] = mon_bc_value
         else:
             correction_factor = mon_bc_value/mon_raw_value
             output_bc_data[:] = input_raw_data[:]*correction_factor
-    else:
-        correction_factor = mon_bc_value - mon_raw_value
-        output_bc_data[:] = input_raw_data[:] + correction_factor
+#    else:
+#        correction_factor = mon_bc_value - mon_raw_value
+#        output_bc_data[:] = input_raw_data[:] + correction_factor
 
     return output_bc_data
 
@@ -283,6 +282,7 @@ for MON in [INIT_FCST_MON]:
             OUTFILE = SUBDAILY_OUTFILE_TEMPLATE.format(OUTDIR, OBS_VAR, \
             FCST_YEAR, FCST_MONTH)
             OUTPUT_BC_DATA = np.ones((NUM_TIMESTEPS, len(LATS), len(LONS)))*-9999.
+
             # Sub-Daily raw data
             SUBDAILY_INFILE = SUBDAILY_INFILE_TEMPLATE.format(\
             SUBDAILY_RAW_FCST_DIR, INIT_FCST_YEAR, ens+1, MONTH_NAME, \
@@ -291,6 +291,7 @@ for MON in [INIT_FCST_MON]:
             MONTHLY_INPUT_RAW_DATAG = xr.open_dataset(SUBDAILY_INFILE)
             INPUT_RAW_DATA = MONTHLY_INPUT_RAW_DATAG.sel(lon=slice(LON1,LON2),lat=slice(LAT1,LAT2))
             MONTHLY_INPUT_RAW_DATA = INPUT_RAW_DATA[FCST_VAR].mean(dim = 'time')
+
             # Bias corrected monthly value
             MON_BC_VALUE = MON_BC_DATA[FCST_VAR][INIT_FCST_YEAR-BC_FCST_SYR, LEAD_NUM, ens,:,:]
 
@@ -325,11 +326,11 @@ for MON in [INIT_FCST_MON]:
             correct2 = np.moveaxis(correct.values,2,0)
             OUTPUT_BC_DATA[:,JJ1:JJ2+1, II1:II2+1] = correct2[:,:,:]
 
-            # massage OUTPUT_BC_DATA to add sub-monthly distribution
+            # Find neighboring OUTPUT_BC_DATA to add sub-monthly distribution
             OUTPUT_BC_REVISED, cnt_beg, cnt_end = use_neighbors_diurnal_cycle (OUTPUT_BC_DATA)
             print (f'NOF cells without precip diurnal cycle : {cnt_beg} (before) {cnt_end} (after)')
 
-            # clip limits
+            # clip limits - 6hr NMME bcsd files:
             OUTPUT_BC_REVISED = limits.clip_array(OUTPUT_BC_REVISED, var_name="PRECTOT", precip=True)
 
             ### Finish correcting values for all timesteps in the given


### PR DESCRIPTION
BCSD Code Updates for LIS 7.5.11 PR
Made the following updates for the BCSD routines:

 - Updated the precipitation minimum threshold to 1.e-7
 - Added -9999 for fill values
 - Included limit checks to monthly BC values (CFSv2 and NMME)
 - Updated upper limit check on NMME monthly precip to 0.004 mm/s
 - Imposed LDT landmask on the MERRA2/CHIRPS + NAFPA observation
    precip when calculating the obs climatology
 - Imposed LDT landmask on NMME precipitation fields
 - Updated the NMME temporal disaggreg script to not operate on
    undefined points (-9999)
 - Implemented current replacement of NMME constant precipitation
    values, with neighbor search to perform temporal disaggeg.;
    If no local CFSv2 gridcell found with precip >0., the NMME BC
    precip is set o 0.
 - Reduced the temporal disagg. search window to 5x5 gridcells,
    since the native CFSv2/NMME gridcells are at 1x1 deg equivalent
    gridspace and want to ensure search over area due to gridcell
    edge-effect.
 - Implemented additional limit checks for CFSv2 BC and temporal
    disaggreg, since negative values are occurring from the BC step.

 Also, reduced some of the BCSD - SLURM wallclock requested hours,
   well within the required times for max. run jobs. This is to
   help ability to get into the SLURM queues a bit faster.

